### PR TITLE
Fix firmware skipping motor init

### DIFF
--- a/src/Motor.cpp
+++ b/src/Motor.cpp
@@ -5,7 +5,16 @@
 void Motor::begin() {
   Serial2.begin(9600, SERIAL_8N1, pin_rx_, pin_tx_);
   delay(200);
-  Serial2.print("ID=123\r\n");
+
+  String msg;
+  Serial2.setTimeout(5000);
+  while (true) {
+    Serial2.print("ID=123\r\n");
+    Serial2.print("ID\r\n");
+    msg = Serial2.readString();
+    if (msg.startsWith("ok123")) { return; }
+    else if (msg.length()) { Serial.printf("%s\n", msg.c_str()); }
+  }
 }
 
 void Motor::set_pos_mm(uint8_t mm) {


### PR DESCRIPTION
Firmware contains an issue where motor initialization happens on microcontroller startup, without verification. If the motor is not yet powered on, this causes motor init to fail silently. This PR fixes that, with the drawback that the microcontroller blocks on the startup screen until motor init is validated.